### PR TITLE
feat: Add `ignore_bots` and `link_issue options`

### DIFF
--- a/.github/workflows/conventional-pr.yml
+++ b/.github/workflows/conventional-pr.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR semantics
-        uses: Namchee/conventional-pr@v0.2.1
+        uses: Namchee/conventional-pr@v0.3.0
         with:
           access_token: ${{ secrets.ACCESS_TOKEN }}

--- a/README.MD
+++ b/README.MD
@@ -26,13 +26,15 @@ A PR is considered to be low quality if it satisfies at least one of these crite
 Simply add this action on one of your GitHub workflows job:
 
 ```yml
-on: pull_request # Run these every new pull request
+on:
+  pull_request:
+    types: [opened, reopened] # Currently, this action only support these events
 
 jobs:
   hqprs:
     runs-on: ubuntu-latest
     steps:
-      - name: hqprs
+      - name: conventional-pr
         uses: Namchee/conventional-pr@v(version)
         with:
           access_token: YOUR_GITHUB_ACCESS_TOKEN_HERE

--- a/README.MD
+++ b/README.MD
@@ -11,7 +11,7 @@ A PR is considered to be low quality if it satisfies at least one of these crite
 - Doesn't follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) style
 - Affects too many file at once. Smaller pull requests are easier to be reviewed, thus keeping the review quality high.
 
-> You can disable checking on draft pull requests, [see below options](#Usage)
+> You can disable checks on draft pull requests, [see below options](#Usage)
 
 ## Features
 
@@ -48,17 +48,19 @@ See it in action [here](https://github.com/Namchee/conventional-pr/blob/master/.
 
 You can customize this actions with these following options (fill it on `with` section):
 
-Name | Required? | Default | Description
+**Name** | **Required?** | **Default Value** | **Description**
 ---- | --------- | ------- | -----------
-`access_token` | `true` | | [GitHub access token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) to interact with GitHub API. It is recommended to store this token with [GitHub Secrets](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets)
+`access_token` | `true` | | [GitHub access token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) to interact with GitHub API. It is recommended to store this token with [GitHub Secrets](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets).
 `close` | `false` | `true` | Determine whether the action should automatically close low quality pull requests.
-`template` | `false` | [See The Metadata](./action.yml) | Comment template to use when commenting on low quality pull requests
+`template` | `false` | [See The Metadata](./action.yml) | Comment template to use when commenting on low quality pull requests.
 `strict` | `false` | `true` | Determine whether the restrictions should apply to repository administrators.
-`label` | `false` | `Nonconventional` | Label to use when marking low quality pull requests. If it doesn't exist, the action will automatically create it.
-`allowed_types` | `false` | `''` | Allowed types according to [conventional commit](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets) style. Fill it with empty string to allow all types.
-`allowed_scopes` | `false` | `''` | Allowed scopes according to [conventional commit](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets) style. Fill it with empty string to allow all scopes.
-`check_draft` | `false` | `false` | Determine whether quality checks should also check draft pull requests.
+`label` | `false` | `Nonconventional` | Label to use when marking low quality pull requests. If it doesn't exist, this action will automatically create it.
+`allowed_types` | `false` | `''` | Allowed types according to [conventional commit](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets) style. Fill it with empty string to allow all types. Comma-separated.
+`allowed_scopes` | `false` | `''` | Allowed scopes according to [conventional commit](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets) style. Fill it with empty string to allow all scopes. Comma-separated.
+`check_draft` | `false` | `false` | Determine whether quality checks should also be applied to draft pull requests.
 `maximum_file_change` | `false` | `0` | Limits how many file can be changed per one pull request. Set it to zero to disable this feature.
+`link_issue` | `false` | `true` | Determine whether a conventional pull request should always have an issue or pull requests references on it.
+`ignore_bot` | `false` | `true` | Determines whether checks should be skipped on PRs that is created by bots. Useful when relying on bots like [dependabot](https://github.com/dependabot)
 
 ## Caveats
 

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,12 @@ inputs:
   template:
     description: 'Comment header on invalid PRs'
     required: false
-    default: "Thank you for your contribution attempt in this repository!\n\nUnfortunately, this pull request doesn't meet our standards by reason we stated below. Please create another pull request that meets our standards in the future."
+    default: |-
+      Thank you for your contribution attempt in this repository!
+      
+      Unfortunately, this pull request doesn't meet our standards by reason we stated below. Please create another pull request that meets our standards in the future.
   strict:
-    description: 'Determine whether the current restriction should apply to maintainers or not'
+    description: 'Determine whether the current restriction should also apply to repository administrators'
     required: false
     default: true
   allowed_types:
@@ -34,9 +37,17 @@ inputs:
     required: false
     default: ''
   maximum_file_change:
-    description: 'Limits how many files should be changes per 1 pull request'
+    description: 'Limits how many files should be changes per pull request'
     required: false
     default: 0
+  link_issue:
+    description: 'Determine whether a conventional PR should always refer to an issue'
+    required: false
+    default: true
+  ignore_bot:
+    description: 'Determine whether PR checking should be skipped on PRs that is created by bots'
+    required: false
+    default: true
 runs:
   using: docker
   image: 'Dockerfile'


### PR DESCRIPTION
## Overview 

This pull request adds two new options to the action:

1. `link_issue`, which determines whether a valid pull request must refer to at least one issue or pull request.
2. `ignore_bot`, which determines whether checks on a bot-submitted pull request should be skipped or not.

Fixes #22.