### PR TITLE
fix: use boolean value true for required constraint

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ author: "Cristopher Namchee"
 inputs:
   access_token:
     description: "GitHub account access token"
-    required: ""
+    required: true
   close:
     description: "Determine whether checks should close invalid PRs"
     required: false


### PR DESCRIPTION
## Overview

Closes #52 

This pull request changes the required constraint value for `access_token` to `true` as intended.