### PR TITLE
chore(ci): always use latest version of golangci-lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,4 +11,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.29
+          version: latest


### PR DESCRIPTION
## Overview

Potentially closes #71 

This pull request fixes the failing `golangci-lint` action by always using the latest version of `golangci-lint`.