### PR TITLE
fix: enable custom API URL for enterprise accounts

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -10,7 +10,7 @@ import (
 )
 
 // GithubClient handles all interaction with Github's API
-// Designed this way for easier software testing
+// Designed this way for easier testing
 type GithubClient interface {
 	GetPullRequest(context.Context, string, string, int) (*github.PullRequest, error)
 	GetUser(context.Context, string) (*github.User, error)
@@ -38,6 +38,8 @@ func NewGithubClient(config *entity.Configuration) GithubClient {
 
 	oauth := oauth2.NewClient(ctx, ts)
 	github := github.NewClient(oauth)
+
+	github.BaseURL = config.BaseURL
 
 	return &githubClient{client: github}
 }

--- a/internal/constants/error.go
+++ b/internal/constants/error.go
@@ -14,6 +14,7 @@ var (
 	ErrInvalidTitlePattern  = errors.New("[Config] Invalid pull request title pattern")
 	ErrInvalidCommitPattern = errors.New("[Config] Invalid pull request commit message pattern")
 	ErrInvalidBranchPattern = errors.New("[Config] Invalid pull request branch name pattern")
+	ErrInvalidBaseURL       = errors.New("[Config] Invalid GitHub API base URL")
 )
 
 // Event error

--- a/internal/entity/config.go
+++ b/internal/entity/config.go
@@ -1,7 +1,9 @@
 package entity
 
 import (
+	"net/url"
 	"regexp"
+	"strings"
 
 	"github.com/Namchee/conventional-pr/internal/constants"
 	"github.com/Namchee/conventional-pr/internal/utils"
@@ -26,6 +28,7 @@ type Configuration struct {
 	Verbose       bool
 	Edit          bool
 	IgnoredUsers  []string
+	BaseURL       *url.URL
 }
 
 // ReadConfig reads environment variables for input values which are supplied
@@ -76,6 +79,16 @@ func ReadConfig() (*Configuration, error) {
 
 	ignoredUsers := utils.ReadEnvStringArray("INPUT_IGNORED_USERS")
 
+	apiUrl := utils.ReadEnvString("GITHUB_API_URL")
+	if !strings.HasSuffix(apiUrl, "/") {
+		apiUrl += "/"
+	}
+
+	baseUrl, err := url.Parse(apiUrl)
+	if err != nil {
+		return nil, constants.ErrInvalidBaseURL
+	}
+
 	return &Configuration{
 		Token:         token,
 		Draft:         draft,
@@ -94,5 +107,6 @@ func ReadConfig() (*Configuration, error) {
 		Signed:        signed,
 		IgnoredUsers:  ignoredUsers,
 		Verbose:       verbose,
+		BaseURL:       baseUrl,
 	}, nil
 }

--- a/internal/entity/config_test.go
+++ b/internal/entity/config_test.go
@@ -1,6 +1,7 @@
 package entity
 
 import (
+	"net/url"
 	"os"
 	"testing"
 
@@ -9,6 +10,8 @@ import (
 )
 
 func TestReadConfig(t *testing.T) {
+	baseUrl, _ := url.Parse("https://api.github.com/")
+
 	tests := []struct {
 		name    string
 		mocks   map[string]string
@@ -31,6 +34,7 @@ func TestReadConfig(t *testing.T) {
 				"INPUT_LABEL":           "cpr:invalid",
 				"INPUT_VERBOSE":         "true",
 				"INPUT_MESSAGE":         "foo bar",
+				"GITHUB_API_URL":        "https://api.github.com/",
 			},
 			want: &Configuration{
 				Token:        "foo_bar",
@@ -46,6 +50,7 @@ func TestReadConfig(t *testing.T) {
 				Edit:         true,
 				Verbose:      true,
 				Message:      "foo bar",
+				BaseURL:      baseUrl,
 			},
 			wantErr: nil,
 		},
@@ -93,6 +98,41 @@ func TestReadConfig(t *testing.T) {
 			},
 			want:    nil,
 			wantErr: constants.ErrInvalidBranchPattern,
+		},
+		{
+			name: "should throw an error when base URL is invalid",
+			mocks: map[string]string{
+				"INPUT_ACCESS_TOKEN": "token",
+				"GITHUB_API_URL":     " https://api.github.com",
+			},
+			want:    nil,
+			wantErr: constants.ErrInvalidBaseURL,
+		},
+		{
+			name: "should not append trailing slash on base URL when URL has trailing slash",
+			mocks: map[string]string{
+				"INPUT_ACCESS_TOKEN": "token",
+				"GITHUB_API_URL":     "https://api.github.com/",
+			},
+			want: &Configuration{
+				Token:        "token",
+				BaseURL:      baseUrl,
+				IgnoredUsers: []string{},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "should append trailing slash on base URL",
+			mocks: map[string]string{
+				"INPUT_ACCESS_TOKEN": "token",
+				"GITHUB_API_URL":     "https://api.github.com",
+			},
+			want: &Configuration{
+				Token:        "token",
+				BaseURL:      baseUrl,
+				IgnoredUsers: []string{},
+			},
+			wantErr: nil,
 		},
 	}
 


### PR DESCRIPTION
## Overview

Closes #90 

This pull request adds support for custom GitHub API URL dictated by the `GITHUB_API_URL` environment variable. The main use-case for this is to account for GitHub enterprise accounts that runs on different API URL.