### PR TITLE
fix: use magic keywords to detect issue linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Filling the input with an empty string will disabled this validator.
 
 This validator checks if the pull request is linked one or more issues.
 
-Do note that linking the issue using [special keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) only works when the target branch is the default branch.
+> Due to current limitations, an issue is considered linked only if the body has [special keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue). Please see [this issue](https://github.com/Namchee/conventional-pr/issues/94) for future solutionss.
 
 ### Pull request does not introduce too many changes
 


### PR DESCRIPTION
## Overvivew

Closes #93.

This pull request fixes issue requirements validator by detecting [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) in the pull request body. 

While this is a good enough solution, this solution cannot detect issue link perfectly if it's [linked manualy](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-to-an-issue-using-the-pull-request-sidebar) which has already been explained in the documentation. Further fixes will be tracked by #94.