### PR TITLE
fix: use Issues endpoint to send verbose report

### DIFF
--- a/.github/workflows/cover.yml
+++ b/.github/workflows/cover.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 2
       - uses: actions/setup-go@v2

--- a/.github/workflows/cpr.yml
+++ b/.github/workflows/cpr.yml
@@ -7,8 +7,10 @@ jobs:
   cpr:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - name: Check PR semantics
-        uses: Namchee/conventional-pr@master
+        uses: ./
         with:
           access_token: ${{ secrets.ACCESS_TOKEN }}
           edit: true
+          verbose: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 vendor
+bin
+.env
+.secrets

--- a/internal/client.go
+++ b/internal/client.go
@@ -307,12 +307,12 @@ func (c *githubClient) CreateComment(
 	prNumber int,
 	body string,
 ) error {
-	_, _, err := c.restClient.PullRequests.CreateComment(
+	_, _, err := c.restClient.Issues.CreateComment(
 		ctx,
 		meta.Owner,
 		meta.Name,
 		prNumber,
-		&github.PullRequestComment{
+		&github.IssueComment{
 			Body: &body,
 		},
 	)
@@ -326,12 +326,12 @@ func (c *githubClient) EditComment(
 	commentID int,
 	body string,
 ) error {
-	_, _, err := c.restClient.PullRequests.EditComment(
+	_, _, err := c.restClient.Issues.EditComment(
 		ctx,
 		meta.Owner,
 		meta.Name,
 		int64(commentID),
-		&github.PullRequestComment{
+		&github.IssueComment{
 			Body: &body,
 		},
 	)

--- a/internal/validator/issue.go
+++ b/internal/validator/issue.go
@@ -2,7 +2,6 @@ package validator
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/Namchee/conventional-pr/internal"
 	"github.com/Namchee/conventional-pr/internal/constants"
@@ -45,7 +44,6 @@ func (v *issueValidator) IsValid(
 		&pullRequest.Repository,
 		pullRequest.Number,
 	)
-	fmt.Println("here")
 	if err != nil {
 		return &entity.ValidationResult{
 			Name:   constants.IssueValidatorName,


### PR DESCRIPTION
## Overview

Closes #101 

This pull request fixes verbose reporting behavior by using the `Issues` endpoint instead of `PullRequests` because apparently, `PullRequests` is used for creating *review comments*.

This change is unintentionally introduced in `v0.15`