### PR TITLE
refactor: test out new build process

### DIFF
--- a/.github/workflows/cpr.yml
+++ b/.github/workflows/cpr.yml
@@ -1,7 +1,7 @@
 name: Check PR semantics
 
 on:
-  pull_request:
+  pull_request_target:
 
 jobs:
   cpr:
@@ -12,3 +12,4 @@ jobs:
         uses: ./
         with:
           access_token: ${{ secrets.ACCESS_TOKEN }}
+  

--- a/.github/workflows/cpr.yml
+++ b/.github/workflows/cpr.yml
@@ -1,7 +1,7 @@
 name: Check PR semantics
 
 on:
-  pull_request_target:
+  pull_request:
 
 jobs:
   cpr:
@@ -12,5 +12,3 @@ jobs:
         uses: ./
         with:
           access_token: ${{ secrets.ACCESS_TOKEN }}
-          edit: true
-          verbose: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18
+FROM golang:1.18 as builder
 
 WORKDIR /ci
 
@@ -9,8 +9,14 @@ RUN go mod download
 
 COPY . .
 
-RUN  go build -a -o cpr .
+ENV GOCACHE=/root/.cache/go-build
+RUN --mount=type=cache,target="/root/.cache/go-build" go build -o cpr .
 
-RUN chmod +x /ci/cpr
+FROM ubuntu:22.04
 
-CMD ["/ci/cpr"]
+RUN mkdir /app
+WORKDIR /app
+
+COPY --from=builder /ci/cpr .
+
+ENTRYPOINT ["/cpr"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ FROM ubuntu:22.04
 RUN mkdir /app
 WORKDIR /app
 
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
+
 COPY --from=builder /ci/cpr /app/cpr
 
 ENTRYPOINT ["/app/cpr"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,6 @@ FROM ubuntu:22.04
 RUN mkdir /app
 WORKDIR /app
 
-COPY --from=builder /ci/cpr .
+COPY --from=builder /ci/cpr /app/cpr
 
-ENTRYPOINT ["./cpr"]
+ENTRYPOINT ["/app/cpr"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ WORKDIR /app
 
 COPY --from=builder /ci/cpr .
 
-ENTRYPOINT ["/cpr"]
+ENTRYPOINT ["./cpr"]


### PR DESCRIPTION
## Overview

Closes #109 

This pull request elevates Go build cache for faster build speeds. Hopefully, it doesn't take nearly 30 seconds just to build the image anymore.