### PR TITLE
fix(ci): change version target to master instead of latest

### DIFF
--- a/.github/workflows/cover.yml
+++ b/.github/workflows/cover.yml
@@ -17,3 +17,4 @@ jobs:
         run: go test ./... -race -coverprofile=coverage.out -covermode=atomic
       - name: Upload coverage to Codecov
         run: bash <(curl -s https://codecov.io/bash)
+

--- a/.github/workflows/cover.yml
+++ b/.github/workflows/cover.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - uses: actions/setup-go@v2

--- a/.github/workflows/cpr.yml
+++ b/.github/workflows/cpr.yml
@@ -8,7 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR semantics
-        uses: Namchee/conventional-pr@latest
+        uses: Namchee/conventional-pr@master
         with:
           access_token: ${{ secrets.ACCESS_TOKEN }}
-

--- a/.github/workflows/cpr.yml
+++ b/.github/workflows/cpr.yml
@@ -11,3 +11,4 @@ jobs:
         uses: Namchee/conventional-pr@master
         with:
           access_token: ${{ secrets.ACCESS_TOKEN }}
+

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,3 +13,4 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: latest
+

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -7,11 +7,11 @@ jobs:
   cpr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Test validation to self
         uses: ./
         with:
-          access_token: ${{ secrets.ACCESS_TOKEN }}
+          access_token: ${{ secrets.GITHUB_TOKEN }}
           edit: true
           verbose: true
 


### PR DESCRIPTION
## Overview

This pull request fixes the CI workflow for self-testing by using the `master` branch instead of `latest` as `latest` is not supported.