### PR TITLE
fix(validator): allow issue validator to accept external issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Filling the input with an empty string will disabled this validator.
   </tr>
 </table>
 
-This validator checks if the pull request is linked one or more issues.
+This validator checks if the pull request is linked one or more issues in the same or different repository.
 
 ### Pull request does not introduce too many changes
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,10 @@ Filling the input with an empty string will disabled this validator.
   </tr>
 </table>
 
-This validator checks if the pull request is linked one or more issues in the same or different repository.
+This validator checks if the pull request is linked one or more issues in the same or different repository either by [directly linking issue through the sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar) or by using [magic closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
+
+> [!NOTE]
+> Ensure that the access token you provide can access issues on the target repository.
 
 ### Pull request does not introduce too many changes
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Filling the input with an empty string will disabled this validator.
 This validator checks if the pull request is linked one or more issues in the same or different repository either by [directly linking issue through the sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar) or by using [magic closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
 
 > [!NOTE]
-> Ensure that the access token you provide can access issues on the target repository.
+> Ensure that the access token you provide can access issues on the target repository
 
 ### Pull request does not introduce too many changes
 

--- a/internal/mocks/client_mock.go
+++ b/internal/mocks/client_mock.go
@@ -158,23 +158,27 @@ func (m *githubClientMock) Close(
 
 func (m *githubClientMock) GetIssue(
 	_ context.Context,
-	_ *entity.Meta,
+	meta *entity.Meta,
 	issueNumber int,
 ) (*entity.IssueReference, error) {
-	switch issueNumber {
-	case 2:
+	if meta.Owner == "vitejs" && meta.Name == "vite" {
 		return &entity.IssueReference{
-			Number: 2,
+			Number: issueNumber,
+			Meta: *meta,
+		}, nil
+	}
+
+	if issueNumber == 3 {
+		return &entity.IssueReference{
+			Number: issueNumber,
 			Meta: entity.Meta{
 				Owner: "Namchee",
 				Name:  "conventional-pr",
 			},
 		}, nil
-	case 3:
-		return &entity.IssueReference{}, nil
-	default:
-		return nil, errors.New("mock error")
 	}
+
+	return nil, errors.New("mock error")
 }
 
 func (m *githubClientMock) GetIssueReferences(
@@ -193,6 +197,8 @@ func (m *githubClientMock) GetIssueReferences(
 			},
 		}, nil
 	case 2:
+		return []*entity.IssueReference{}, nil
+	case 3:
 		return []*entity.IssueReference{}, nil
 	default:
 		return nil, errors.New("mock error")

--- a/internal/validator/issue.go
+++ b/internal/validator/issue.go
@@ -12,7 +12,8 @@ import (
 )
 
 var (
-	keywordPattern = regexp.MustCompile(`(?mi)\b(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s+(.+/.+)?#(\d+)\b`)
+	// TODO: Investigate allowed characters for orgs and repositories
+	keywordPattern = regexp.MustCompile(`(?mi)\b(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s+([a-zA-Z0-9\-]+/[a-zA-Z0-9\-\._]+)?#(\d+)\b`)
 )
 
 type issueValidator struct {

--- a/internal/validator/issue.go
+++ b/internal/validator/issue.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/Namchee/conventional-pr/internal"
 	"github.com/Namchee/conventional-pr/internal/constants"
@@ -11,7 +12,7 @@ import (
 )
 
 var (
-	keywordPattern = regexp.MustCompile(`(?mi)\b(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved) #(\d+)\b`)
+	keywordPattern = regexp.MustCompile(`(?mi)\b(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s+(.+/.+)?#(\d+)\b`)
 )
 
 type issueValidator struct {
@@ -87,17 +88,27 @@ func (v *issueValidator) IsValid(
 }
 
 func (v *issueValidator) hasIssueMagicString(
-	ctx context.Context,
+	_ context.Context,
 	pullRequest *entity.PullRequest,
 ) bool {
 	keywords := keywordPattern.FindAllStringSubmatch(pullRequest.Body, -1)
 
-	for _, number := range keywords {
-		num, _ := strconv.Atoi(number[2])
+	for _, keyword := range keywords {
+		org := &pullRequest.Repository
+		num, _ := strconv.Atoi(keyword[3]) 
+
+		if len(keyword[2]) > 0 {
+			tokens := strings.Split(keyword[2], "/")
+
+			org = &entity.Meta{
+				Name: tokens[1],
+				Owner: tokens[0],
+			}
+		}
 
 		issue, _ := v.client.GetIssue(
 			context.Background(),
-			&pullRequest.Repository,
+			org,
 			num,
 		)
 

--- a/internal/validator/issue_test.go
+++ b/internal/validator/issue_test.go
@@ -71,23 +71,7 @@ func TestIssueValidator_IsValid(t *testing.T) {
 			},
 		},
 		{
-			name: "should reject if reference is not on the same repository",
-			args: args{
-				prNumber: 1,
-				meta: &entity.Meta{
-					Name:  "conventional-pr",
-					Owner: "namcheee",
-				},
-				config: true,
-			},
-			want: &entity.ValidationResult{
-				Name:   constants.IssueValidatorName,
-				Active: true,
-				Result: constants.ErrNoIssue,
-			},
-		},
-		{
-			name: "should pass if issue is referenced as magic string",
+			name: "should pass if issue is referenced as magic string in the same repository",
 			args: args{
 				prNumber: 2,
 				meta: &entity.Meta{
@@ -101,6 +85,40 @@ func TestIssueValidator_IsValid(t *testing.T) {
 				Name:   constants.IssueValidatorName,
 				Active: true,
 				Result: nil,
+			},
+		},
+		{
+			name: "should pass if issue is referenced as magic string in different repository",
+			args: args{
+				prNumber: 3,
+				meta: &entity.Meta{
+					Name:  "conventional-pr",
+					Owner: "namcheee",
+				},
+				body:   "Closes    vitejs/vite#1783",
+				config: true,
+			},
+			want: &entity.ValidationResult{
+				Name:   constants.IssueValidatorName,
+				Active: true,
+				Result: nil,
+			},
+		},
+		{
+			name: "should reject if issue is not accessible",
+			args: args{
+				prNumber: 2,
+				meta: &entity.Meta{
+					Name:  "conventional-pr",
+					Owner: "namcheee",
+				},
+				body:   "Closes #4",
+				config: true,
+			},
+			want: &entity.ValidationResult{
+				Name:   constants.IssueValidatorName,
+				Active: true,
+				Result: constants.ErrNoIssue,
 			},
 		},
 		{

--- a/internal/validator/issue_test.go
+++ b/internal/validator/issue_test.go
@@ -105,6 +105,23 @@ func TestIssueValidator_IsValid(t *testing.T) {
 			},
 		},
 		{
+			name: "should pass if provided by multiple references",
+			args: args{
+				prNumber: 3,
+				meta: &entity.Meta{
+					Name:  "conventional-pr",
+					Owner: "namcheee",
+				},
+				body:   "Closed #3. Fixes vitejs/vite#1783",
+				config: true,
+			},
+			want: &entity.ValidationResult{
+				Name:   constants.IssueValidatorName,
+				Active: true,
+				Result: nil,
+			},
+		},
+		{
 			name: "should reject if issue is not accessible",
 			args: args{
 				prNumber: 2,


### PR DESCRIPTION
## Overview

Closes #126 

This pull request allows issue validator to accept references to issues on different repositories.

Do note that the access token needs to have access to the said repository, else it won't work.