### PR TITLE
fix: return error when constructing Github client

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -34,7 +34,7 @@ type githubClient struct {
 }
 
 // NewGithubClient instatiates a new GitHub client API interface
-func NewGithubClient(config *entity.Configuration) GithubClient {
+func NewGithubClient(config *entity.Configuration) (GithubClient, error) {
 	ctx := context.Background()
 
 	ts := oauth2.StaticTokenSource(
@@ -43,13 +43,17 @@ func NewGithubClient(config *entity.Configuration) GithubClient {
 
 	client := oauth2.NewClient(ctx, ts)
 
-	restClient, _ := github.NewClient(client).WithEnterpriseURLs(config.RestURL, config.RestURL)
+	restClient, err := github.NewClient(client).WithEnterpriseURLs(config.RestURL, config.RestURL)
+	if err != nil {
+		return nil, err
+	}
+
 	gqlClient := githubv4.NewEnterpriseClient(config.GraphQLURL, client)
 
 	return &githubClient{
 		gqlClient:  gqlClient,
 		restClient: restClient,
-	}
+	}, nil
 }
 
 func (c *githubClient) GetPullRequest(

--- a/internal/client_test.go
+++ b/internal/client_test.go
@@ -1,3 +1,0 @@
-package internal
-
-

--- a/internal/client_test.go
+++ b/internal/client_test.go
@@ -1,0 +1,44 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/Namchee/conventional-pr/internal/entity"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewGithubClient(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *entity.Configuration
+		wantErr bool
+	}{
+		{
+			name: "should return nil when GitHub URL is malformed",
+			config: &entity.Configuration{
+				RestURL: "https://api.github.com:123a",
+			},
+			wantErr: true,
+		},
+		{
+			name: "should return client when GitHub URL is valid",
+			config: &entity.Configuration{
+				RestURL: "https://api.github.com/",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client, err := NewGithubClient(tc.config)
+
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, client)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -58,7 +58,10 @@ func main() {
 	}
 
 	infoLogger.Println("Initializing GitHub Client")
-	client := internal.NewGithubClient(config)
+	client, err := internal.NewGithubClient(config)
+	if err != nil {
+		errorLogger.Fatalf("Failed to construct GitHub client, URL might be malformed: %s", err.Error())
+	}
 
 	infoLogger.Println("Reading pull request metadata")
 	event, err = entity.ReadEvent(os.DirFS("/"))


### PR DESCRIPTION
## Overview

Closes #130

This pull request applies error check when constructing GitHub client by returning error and evaluating the error in the entrypoint.

While it's most likely won't happen, it wouldn't hurt to check!